### PR TITLE
Update to 2.49.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This action sets up GitHub CLI tool. It downloads GitHub CLI binaries from https
 
    
 # Usage
-## Set up default GitHub CLI version (2.48.0)
+## Set up default GitHub CLI version (2.49.2)
 ```yaml
 - uses: freenet-actions/setup-github-cli@v3
 ```
@@ -15,5 +15,5 @@ This action sets up GitHub CLI tool. It downloads GitHub CLI binaries from https
 ```yaml
 - uses: freenet-actions/setup-github-cli@v3
   with:
-    version: 2.48.0
+    version: 2.49.2
 ```

--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ inputs:
   version: 
     required: true
     description: 'Version of GitHub CLI'
-    default: '2.48.0'
+    default: '2.49.2'
 runs:
   using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
Die neue Version gibt es seit drei Tagen: https://github.com/cli/cli/releases/tag/v2.49.2

Danach müssen wir dann wohl mal neue Tags hier im Repo generien via https://github.com/freenet-actions/setup-github-cli/actions/workflows/build-test-release.yml